### PR TITLE
Add distributionSha256Sum to gradle.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionSha256Sum=71a787faed83c4ef21e8464cc8452b941b5fcd575043aa29d39d15d879be89f7


### PR DESCRIPTION
Hello,

This checksum is used by Gradle to check the binary it downloads.